### PR TITLE
Capitalize "First Aid" skill name

### DIFF
--- a/data/text/english/game/skill.msg
+++ b/data/text/english/game/skill.msg
@@ -10,7 +10,7 @@
 {103}{}{Unarmed}
 {104}{}{Melee Weapons}
 {105}{}{Throwing}
-{106}{}{First aid}
+{106}{}{First Aid}
 {107}{}{Doctor}
 {108}{}{Sneak}
 {109}{}{Lockpick}


### PR DESCRIPTION
Not quite sure about this one, but every other skill/perk/trait name is using title case.