### PR TITLE
Attempt to fix Modoc shitcave molerat from disappearing

### DIFF
--- a/scripts_src/modoc/mcmolrat.ssl
+++ b/scripts_src/modoc/mcmolrat.ssl
@@ -109,6 +109,7 @@ procedure map_enter_p_proc begin
             set_self_ai(AI_GENERIC_RAT);
          end
       end
+      if (cur_map_index != MAP_MODOC_DOWNTHESHITTER) then
       critter_attempt_placement(self_obj, local_var(LVAR_Home_Tile), self_elevation);
    end
 end


### PR DESCRIPTION
local_var(LVAR_Home_Tile) resets to <0, if you leave without killing the molerat after molerat has attacked you. causing molerat to disappear when you go back