### PR TITLE
fix for SLAVE_SKEEV

### DIFF
--- a/scripts_src/valtcity/vcbarkus.ssl
+++ b/scripts_src/valtcity/vcbarkus.ssl
@@ -247,7 +247,7 @@ procedure talk_p_proc begin
        gSay_End;
        end_dialogue;
    end
-   else if( map_var( MVAR_Player_As_Slave ) == SLAVE_SKEEV ) then begin
+   else if( ( map_var( MVAR_Player_As_Slave ) == SLAVE_SKEEV ) and dude_is_stupid ) then begin
        start_gdialog(NAME,self_obj,4,-1,-1);
        gSay_Start;
            call Node033;

--- a/scripts_src/valtcity/vcskeeve.ssl
+++ b/scripts_src/valtcity/vcskeeve.ssl
@@ -369,7 +369,7 @@ procedure talk_p_proc begin
    else if( ( global_var( GVAR_VAULT_CITIZEN ) == CITIZEN_SKEEVE_GIVEN_FAKE ) or
             ( global_var( GVAR_VAULT_CITIZEN ) == CITIZEN_GUARD_BELIEVE_FAKE ) ) then
       call Node005;
-   else if( map_var( MVAR_Player_As_Slave ) == SLAVE_SKEEV ) then begin
+   else if( ( map_var( MVAR_Player_As_Slave ) == SLAVE_SKEEV ) and dude_is_stupid ) then begin
       start_gdialog(NAME,self_obj,4,-1,-1);
       gSay_Start;
          call Node035;


### PR DESCRIPTION
If you are SLAVE_SKEEVE but not stupid - talk to Skeeve or Barkus, dialog is broken and nothing happens:
![scr00000](https://user-images.githubusercontent.com/19704782/211266907-6c4b6d51-1223-41b9-bbab-24fcb5eb6458.png)
![scr00001](https://user-images.githubusercontent.com/19704782/211266929-ae14a5e4-b411-4934-8e93-c574cc153b7a.png)
[SLOT07.zip](https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/files/10371592/SLOT07.zip)

This happens because following nodes work for stupid dude only:
https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/blob/master/scripts_src/valtcity/vcbarkus.ssl#L848
https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/blob/master/scripts_src/valtcity/vcskeeve.ssl#L853

That's why I've added additional check for dude_is_stupid.