### PR TITLE
Add missing critters_walk_faster setting to upu.ini

### DIFF
--- a/extra/inno/components_ammo.iss
+++ b/extra/inno/components_ammo.iss
@@ -1,5 +1,5 @@
 Name: "ammo"; Description: "Ammo damage formula"; Types: "custom";
 Name: "ammo\default"; Description: "Default"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\glovz"; Description: "Glovz's"; Flags: exclusive disablenouninstallwarning;
-Name: "ammo\glovz_mult"; Description: "Glovz's with damage multiplier fix"; Flags: exclusive disablenouninstallwarning;
+Name: "ammo\glovz_mult"; Description: "Glovz's with damage multiplier tweak"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\yaam"; Description: "YAAM"; Flags: exclusive disablenouninstallwarning;

--- a/release/mods/upu.ini
+++ b/release/mods/upu.ini
@@ -4,6 +4,10 @@
 ; This setting has no effect if alternative low FPS Goris de-robing is installed.
 goris_derobing_speed=50
 
+; Some critters (robots, various guards, etc) walk much slower than others. This speeds them up a bit. Just cosmetic.
+; This setting has no effect if alternative low FPS walk speed fix is installed.
+critters_walk_faster=1
+
 ; Wipe merchant inventories before restock.
 ; If disabled, all merchants will keep all items you ever sold to them forever (in addition to stock refreshements).
 ; If enabled, they will get fresh inventory on each restock.


### PR DESCRIPTION
It was added to RPU's `upu.ini` first, didn't get synced to UPU.
Also change the description of Glovz's ammo mod a little (it's a tweak not a fix).