### PR TITLE
Reduce logging from two FRM speed global scripts

### DIFF
--- a/scripts_src/global/gl_k_goris_derobing.ssl
+++ b/scripts_src/global/gl_k_goris_derobing.ssl
@@ -20,36 +20,36 @@ procedure start begin
     if speed < min_speed then speed = min_speed;
     if speed > max_speed then speed = max_speed;
 
-      variable fs_override = check_filesystem_override;
-      if not fs_override then begin
-        ndebug("fs override disabled, aborting");
-        return false;
+    variable fs_override = check_filesystem_override;
+    if not fs_override then begin
+      ndebug("fs override disabled, aborting");
+      return;
+    end
+
+    variable frm, file, path;
+    variable fps_offset = 0x4;
+    variable fps = speed;
+    variable frms = [
+      "madethag",
+      "marobeag"
+    ];
+
+    foreach frm in frms begin
+      variable cur_frame_count;
+      path = "art\\critters\\" + frm + ".frm";
+      file = fs_copy(path, path);
+
+      fs_seek(file, frame_count_offset);
+      cur_frame_count = fs_read_short(file);
+      if cur_frame_count >= min_frame_count then begin
+        fs_seek(file, fps_offset);
+        fs_write_short(file, fps);
+        //ndebug("set fps to " + fps + " in " + path);
+      end else begin
+        ndebug("low frame count detected in " + path + ", not boosting fps");
       end
-
-      variable frm, file, path;
-      variable fps_offset = 0x4;
-      variable fps = speed;
-      variable frms = [
-        "madethag",
-        "marobeag"
-      ];
-      ndebug("initialized");
-
-      foreach frm in frms begin
-        variable cur_frame_count;
-        path = "art\\critters\\" + frm + ".frm";
-        file = fs_copy(path, path);
-
-        fs_seek(file, frame_count_offset);
-        cur_frame_count = fs_read_short(file);
-        if cur_frame_count >= min_frame_count then begin
-          fs_seek(file, fps_offset);
-          fs_write_short(file, fps);
-          ndebug("set fps to " + fps + " in " + path);
-        end else begin
-          ndebug("low frame count detected in " + path + ", not boosting fps");
-        end
-      end
+    end
+    ndebug("initialized");
 
   end
 end

--- a/scripts_src/global/gl_k_walking_speed.ssl
+++ b/scripts_src/global/gl_k_walking_speed.ssl
@@ -65,7 +65,7 @@ procedure get_slow_frms begin
     "nmrgngh",
     "nmrgngi",
     "nmrgngj",
-    "nmrgngk"  
+    "nmrgngk"
   ];
   return slow_walk_frms;
 end
@@ -73,31 +73,30 @@ end
 procedure start begin
   if game_loaded then begin
     enabled = upu_msetting(set_walking_speed);
-    if enabled != 0 then begin
-      variable fs_override = check_filesystem_override;
-      if not fs_override then begin
-        ndebug("fs override disabled, aborting");
-        return false;
-      end
+    if enabled == 0 then return;
 
-      variable frm, frms, file, path, cur_frame_count;
-      frms = get_slow_frms;
-      ndebug("initializing");
-      foreach frm in frms begin
-        path = "art\\critters\\" + frm + "b.frm";
-        file = fs_copy(path, path);
-        fs_seek(file, frame_count_offset);
-        cur_frame_count = fs_read_short(file);
-        if cur_frame_count > 8 then begin
-          fs_seek(file, fps_offset);
-          fs_write_short(file, cur_frame_count); // 1 step per second
-          ndebug("set fps to " + cur_frame_count + " in " + path);
-        end else begin
-          ndebug("low frame count detected in " + path + ", not boosting fps");
-        end
-      end
-      ndebug("initialized");
-
+    variable fs_override = check_filesystem_override;
+    if not fs_override then begin
+      ndebug("fs override disabled, aborting");
+      return;
     end
+
+    variable frm, frms, file, path, cur_frame_count;
+    frms = get_slow_frms;
+    foreach frm in frms begin
+      path = "art\\critters\\" + frm + "b.frm";
+      file = fs_copy(path, path);
+      fs_seek(file, frame_count_offset);
+      cur_frame_count = fs_read_short(file);
+      if cur_frame_count > 8 then begin
+        fs_seek(file, fps_offset);
+        fs_write_short(file, cur_frame_count); // 1 step per second
+        //ndebug("set fps to " + cur_frame_count + " in " + path);
+      end else begin
+        ndebug("low frame count detected in " + path + ", not boosting fps");
+      end
+    end
+    ndebug("initialized");
+
   end
 end


### PR DESCRIPTION
Based on [phobos's comment](https://github.com/BGforgeNet/Fallout2_Restoration_Project/pull/232#issuecomment-1699075661) in the PR for RPU.
Doesn't seem necessary to log each of them IMO, logging low-fps/skipped ones should be enough for the (rare) case someone mixed low-fps FRMs from alternative animations repo.