### PR TITLE
Fixed inconsistent spelling of some terms.

### DIFF
--- a/data/text/english/dialog/ecravpty.msg
+++ b/data/text/english/dialog/ecravpty.msg
@@ -4,7 +4,7 @@
 #edit below by killap - was 202
 {210}{}{It seems she's been sampling some of her own merchandise.}
 {103}{}{Wha... whas..what cans I gets yas. [Hick.]}
-{104}{}{Nuka Cola [$6]}
+{104}{}{Nuka-Cola [$6]}
 {105}{}{Beer [$15]}
 {106}{}{Booze [$30]}
 {107}{}{Nothing today. Thanks.}

--- a/data/text/english/dialog/fcdrfung.msg
+++ b/data/text/english/dialog/fcdrfung.msg
@@ -5,7 +5,7 @@
 {104}{}{Owie! Ouch! Owwwwwww!}
 {105}{}{Yeah - I'm hurt and it looks like you're a doctor.}
 {106}{}{Yes. I need a doctor for my friend.}
-{107}{}{Do you have any stimpacks? I'd like to buy some.}
+{107}{}{Do you have any stimpaks? I'd like to buy some.}
 {108}{}{Who are you?}
 {109}{}{I have a friend who's missing a spleen. Can you help him?}
 {110}{}{What can you tell me about this place?}
@@ -43,7 +43,7 @@
 {142}{}{Forget it.}
 
 {158}{}{What? You do not have the money? How do you expect me to survive if you ask me for free healing?}
-{159}{}{Do you have stimpacks?}
+{159}{}{Do you have stimpaks?}
 {160}{}{No thanks.}
 {161}{}{It has been a pleasure doing business with you.}
 {162}{}{Thanks.}

--- a/data/text/english/dialog/hcdoc.msg
+++ b/data/text/english/dialog/hcdoc.msg
@@ -11,7 +11,7 @@
 {108}{}{What do you do here?}
 {109}{}{Tell me about the town.}
 {110}{}{Any gossip?}
-{111}{}{Just sell me some stimpacks.}
+{111}{}{Just sell me some stimpaks.}
 
 {112}{}{Forget it. Sorry.}
 
@@ -83,9 +83,9 @@ because this is going to cost ::cough:: $200.}
 {157}{}{I'll pay.}
 {158}{}{Forget it.}
 
-{159}{}{Friend, you don't have that kind of money. I can sell you some stimpacks if you like, but with
+{159}{}{Friend, you don't have that kind of money. I can sell you some stimpaks if you like, but with
  the healing you're looking for, you can't afford what I can afford to give you.}
-{160}{}{Give me the stimpacks.}
+{160}{}{Give me the stimpaks.}
 {161}{}{No thanks.}
 
 {162}{}{It's been a pleasure.}

--- a/data/text/english/dialog/nccody.msg
+++ b/data/text/english/dialog/nccody.msg
@@ -42,7 +42,7 @@
 {239}{}{Well, see you later, Cody. Take care.}
 
 # 5. DRINK (2, 4)
-{251}{}{Hey, Cody. Want some nuka cola?}
+{251}{}{Hey, Cody. Want some Nuka-Cola?}
 {252}{}{Want a brewski, kid? Never too young to start, Mom used to say. Uh, when she was sober, that is.}
 {253}{}{I got some Jet here, Cody. You want to fly high with Uncle }
 {254}{}{I got some Jet here, Cody. You want to fly high with Auntie }

--- a/data/text/english/dialog/ncwritee.msg
+++ b/data/text/english/dialog/ncwritee.msg
@@ -29,7 +29,7 @@
 {209}{}{I thought the President was a myth, a boogeyman used to scare children.}
 {210}{}{You look like you've been through hell and back. Relax for a while. You deserve it.}
 {211}{}{You gonna replay the game as a different character? I recommend an Outdoorsman type.}
-{212}{}{F.E.V.? What's that?}
+{212}{}{FEV? What's that?}
 {213}{}{New Reno was designed by Chris Avellone and scripted by Tom French. Tom plays in a band. Chris plays with himself.}
 {214}{}{I hope I get to be a major character in Fallout 3, like Tandi or Ian. Bein' a thug sucks.}
 {215}{}{Heard you busted up that Enclave down South. You're pretty brave.}

--- a/data/text/english/dialog/nhmyron.msg
+++ b/data/text/english/dialog/nhmyron.msg
@@ -54,7 +54,7 @@
 {268}{}{You should be glad I'm with you to point out all your stupid mistakes.}
 
 # 8. I'M HURT (WTG)
-{375}{}{Hey, I'm dying over here! Give me a stimpack already!}
+{375}{}{Hey, I'm dying over here! Give me a stimpak already!}
 {376}{}{Is this my blood?}
 {377}{}{Medic!}
 {378}{}{Owwwww. Fuck! Owwwww, that hurts!}
@@ -63,8 +63,8 @@
 {381}{}{Owwww. Wish SOMEONE would patch these wounds.}
 
 # 9. I'M BADLY HURT (WTG)
-{390}{}{Give me a goddamn stimpack before I pass out!}
-{391}{}{Give me a damn stimpack! I'm going into shock!}
+{390}{}{Give me a goddamn stimpak before I pass out!}
+{391}{}{Give me a damn stimpak! I'm going into shock!}
 {392}{}{Somebody give me some first aid, fast! I'm dying here!}
 
 # 10. I'M POISONED (WTG)
@@ -115,7 +115,7 @@
 {466}{}{Nothing like a strict drug regimen to keep my mind limber.}
 {467}{}{This doesn't mean we're married, does it?}
 {468}{}{Got any weed?}
-{469}{}{Let me hold the stimpacks, okay?}
+{469}{}{Let me hold the stimpaks, okay?}
 {470}{}{Ahhhhhhhhh.}
 {471}{}{Ooooooohhh. Aaaaaaaah. Mmmmmm.}
 {472}{}{I love it when you do that.}
@@ -173,13 +173,13 @@
 # 21. USE HEALING (WOUNDED) (WTG)
 {560}{}{Don't need to tell me twice.}
 {561}{}{I could use some womanly healing, know what I mean?}
-{562}{}{Ahhhhhhh. Good thing stimpacks aren't too addictive.}
-{563}{}{Oooooh, yeah. Good thing stimpacks aren't too addictive.}
+{562}{}{Ahhhhhhh. Good thing stimpaks aren't too addictive.}
+{563}{}{Oooooh, yeah. Good thing stimpaks aren't too addictive.}
 
 # 22. USE HEALING (NOT WOUNDED) (WTG)
 {570}{}{Don't inject me with that shit. I'm fine, okay?}
 {571}{}{Stop mothering me. I'm all right.}
-{572}{}{Hey, don't sweat it. I'm fine. But let me hold the stimpacks anyway.}
+{572}{}{Hey, don't sweat it. I'm fine. But let me hold the stimpaks anyway.}
 
 # 23. WAITING (WTG)
 {580}{}{Hey, let me join you again! C'mon!}
@@ -455,8 +455,8 @@
 {1036}{myn143b}{Hey, can't get enough, huh? Whaddya need?}
 {1037}{}{An antidote for radscorpion venom.}
 {1038}{}{Some Jet.}
-{1039}{}{Some stimpacks.}
-{1040}{}{Can you make super stimpacks?}
+{1039}{}{Some stimpaks.}
+{1040}{}{Can you make super stimpaks?}
 {1041}{}{Nothing. I had some other questions...}
 {1042}{}{Nevermind.}
 
@@ -492,25 +492,25 @@
 {1105}{myn149a}{Piece of cake. How many packs you want?}
 {1106}{myn149b}{Hey, genius. Ever cross your mind that it might be easier just to stay outta trouble, huh? OK, how many?}
 {1107}{myn149c}{Just tell me how much and where you want it, beautiful.}
-{1111}{}{Make as many stimpacks as you can from what we're carrying.}
-{1113}{}{Can you make super stimpacks?}
+{1111}{}{Make as many stimpaks as you can from what we're carrying.}
+{1113}{}{Can you make super stimpaks?}
 {1114}{}{Forget it. I had some questions...}
 
 # 151. CAN'T MAKE STIM-PACKS (143)
 {1125}{myn151}{Sorry, we just ain't got what I need to whip up a stim. Let's see: You'll need some xander root... some broc flower... and an empty hypo.}
 {1126}{}{Can you make some other drugs?}
-{1127}{}{If you can make stimpacks, couldn't you make some super stimpacks?}
+{1127}{}{If you can make stimpaks, couldn't you make some super stimpaks?}
 {1128}{}{All right then. I had some questions...}
 
 # 152. CAN'T MAKE SUPER STIM-PACKS (143, 151)
-{1135}{myn152}{Of course I could...'cept we ain't got what I need. Some of that mutated fruit for the citric acid... a splash a' Nuka Cola... and a normal stim pack.}
+{1135}{myn152}{Of course I could...'cept we ain't got what I need. Some of that mutated fruit for the citric acid... a splash a' Nuka-Cola... and a normal stim pack.}
 
 # 153. MAKE SUPER STIM-PACKS (143, 151)
 {1145}{myn153a}{Repeat after me: Myron's a genius. How many packs you want?}
 {1146}{myn153b}{How about. Stay. Out. Of. Trouble? Nevermind, obviously too tough a concept. How many this time?}
 {1147}{myn153c}{Myron's your man, beautiful. How many?}
 {1149}{}{Give me two.}
-{1151}{}{Make as many stimpacks as you can from what we're carrying.}
+{1151}{}{Make as many stimpaks as you can from what we're carrying.}
 
 # 201. INTRO (WTG)
 {1170}{myn201a}{Who're you an' how the hell did you get in here? Wh-where are those jackass guards?}
@@ -838,7 +838,7 @@
 # 1001. HEALING (101, 1001, 1003, 1004, 1005, 1006)
 {1745}{myrn104a}{Stop mothering me.}
 {1746}{myn104b}{Owww! Hurts! It hur - oh, it. No. No, I'm pretty much okay. Stings a little.}
-{1747}{myn104c}{I'm dying over here! Gi-give me a stimpack. Or two. Or three.}
+{1747}{myn104c}{I'm dying over here! Gi-give me a stimpak. Or two. Or three.}
 {1748}{myn104d}{Is... that... you? Can't... see... losing... consciousness. *Cough* *Cough* Help... me...}
 {1749}{}{Hmmmm. Heal yourself again.}
 {1753}{}{Give me a little distance, Myron.}

--- a/data/text/english/dialog/qccurlng.msg
+++ b/data/text/english/dialog/qccurlng.msg
@@ -57,7 +57,7 @@
 {156}{}{No, not really. You're actually rather different, at least your DNA is. A rather unfortunate effect of generations of background radiation, I assume.}
 {157}{}{So what if our DNA is a little different?}
 {158}{}{I don't know what that means, but so what if we're a little different?}
-{159}{}{Oh, your DNA is more than just a *little* different. It's quite different. If I weren't so pressed for time by the Project I'd be interested in running further tests on your people, other than the F.E.V. toxicological study, of course. Fascinating work really.}
+{159}{}{Oh, your DNA is more than just a *little* different. It's quite different. If I weren't so pressed for time by the Project I'd be interested in running further tests on your people, other than the FEV toxicological study, of course. Fascinating work really.}
 {160}{}{What did you want to know about?}
 {161}{}{How's our DNA different?}
 {162}{}{You're running tests on my tribe?}
@@ -92,27 +92,27 @@
 {191}{}{Your kind clearly isn't capable of understanding what I'm trying to tell you. It's hopeless. You should leave now.}
 {192}{}{Well, I tried. Time to die, bigot.}
 {193}{}{All right, I'm going. One of us is hopeless and I don't think it's me. Goodbye.}
-{194}{}{Toxicological studies on the effectiveness of the F.E.V. toxin, yes.}
-{195}{}{The F.E.V. toxin? What's that?}
+{194}{}{Toxicological studies on the effectiveness of the FEV toxin, yes.}
+{195}{}{The FEV toxin? What's that?}
 {196}{}{Let me ask you about something else.}
-{197}{}{The F.E.V. toxin. It's the perfect solution for this difficult problem.}
-{198}{}{What's the F.E.V. toxin?}
+{197}{}{The FEV toxin. It's the perfect solution for this difficult problem.}
+{198}{}{What's the FEV toxin?}
 {199}{}{Wait a minute. Let me ask you something else.}
-{200}{}{One of our patrols found the research data, and several samples, about the F.E.V. virus in a former military research base that had been almost completely destroyed.}
+{200}{}{One of our patrols found the research data, and several samples, about the FEV virus in a former military research base that had been almost completely destroyed.}
 {201}{}{Okay, now I know where you found it, but what does it do?}
-{202}{}{The F.E.V. was initially designed as a virus that was supposed to turn humans into super-soldiers. That experiment seems to have been an utter failure, although I did try a modification of the virus on one of our Secret Service agents with some success.}
+{202}{}{The FEV was initially designed as a virus that was supposed to turn humans into super-soldiers. That experiment seems to have been an utter failure, although I did try a modification of the virus on one of our Secret Service agents with some success.}
 {203}{}{Great for you, but how does that have anything to do with eradicating everyone?}
-{204}{}{Oh, yes, well, I was getting to that... The F.E.V. virus bond is species specific, it will only bond with human glycoprotein. It only took a few years to tweak the F.E.V. virus to make it more lethal than it already was. The result was just what the doctor ordered, perfect in every way. }
+{204}{}{Oh, yes, well, I was getting to that... The FEV virus bond is species specific, it will only bond with human glycoprotein. It only took a few years to tweak the FEV virus to make it more lethal than it already was. The result was just what the doctor ordered, perfect in every way. }
 {205}{}{Perfect? How so?}
-{206}{}{Isn't it obvious, my mutated friend? The F.E.V. is, thanks to me, a lethal toxin, and thanks to some mysterious genius named, rather dramatically, the Master, it only works on humans, mutated or not.}
+{206}{}{Isn't it obvious, my mutated friend? The FEV is, thanks to me, a lethal toxin, and thanks to some mysterious genius named, rather dramatically, the Master, it only works on humans, mutated or not.}
 {207}{}{So?}
 {208}{}{That means that we have the perfect disposal device for all of the near-human mutants infecting the globe.}
 {209}{}{I still don't understand how that's *perfect.*}
 {210}{}{I've got to ask you about some of your other crazy ideas.}
-{211}{}{The F.E.V. toxin will only attack humans, leaving everything else alive. Better still, within a month all the mutants will be dead and the F.E.V. toxin will die out as soon as it runs out of hosts.}
-{212}{}{There can't be enough verti-birds here to spread the toxin all over the globe.}
+{211}{}{The FEV toxin will only attack humans, leaving everything else alive. Better still, within a month all the mutants will be dead and the FEV toxin will die out as soon as it runs out of hosts.}
+{212}{}{There can't be enough vertibirds here to spread the toxin all over the globe.}
 {213}{}{I'm going to make you a host to some high-energy projectiles. Say your prayers.}
-{214}{}{You're right, there aren't. But we don't need them. We have a release system that will spray the F.E.V. toxin straight from the vats to the outside atmosphere. The Jet stream will take care of the rest. Global saturation within two weeks.}
+{214}{}{You're right, there aren't. But we don't need them. We have a release system that will spray the FEV toxin straight from the vats to the outside atmosphere. The Jet stream will take care of the rest. Global saturation within two weeks.}
 {215}{}{Two weeks?}
 {216}{}{Yes, two weeks for the virus to spread, another month or so for it to run its course and then the United States will be ready for recolonization by real humans. Our species will have been saved.}
 {217}{}{You really think you're doing the right thing don't you?}
@@ -134,10 +134,10 @@
 {233}{}{More drastic? What do you mean?}
 {234}{}{The Enclave must be destroyed. Completely destroyed. If we're not, then we'll just pick up the pieces and start over somewhere else.}
 {235}{}{I'm sorry to hear that. Uh, Doctor, how do you suggest that the Enclave be destroyed?}
-{236}{}{I think that the best way is to just release the F.E.V. toxin into the air-filtration system. Since the Enclave is a sealed system that should take care of everyone.}
+{236}{}{I think that the best way is to just release the FEV toxin into the air-filtration system. Since the Enclave is a sealed system that should take care of everyone.}
 {237}{}{What about my people? Or me? Or you, for that matter?}
 {238}{}{I can release the antidote into the air-system for all the cells. The detention level is served by a separate air system from the rest of the Enclave. Everyone will think that I'm just running another test. You, I can inoculate directly, here and now. (he reaches for you with a syringe)}
-{239}{}{Ouch, thanks Doc. What happens when the F.E.V. toxin is released?}
+{239}{}{Ouch, thanks Doc. What happens when the FEV toxin is released?}
 {240}{}{Hey, wait a minute, you're not sticking me with that thing!}
 {241}{}{It's not pretty. You should leave as soon as possible. But I'd rather have the weight of a thousand on my conscience than several hundred-thousand. Our time is through here. We had our chance.}
 {242}{}{How can I free my people from the detention area?}
@@ -158,7 +158,7 @@
 {257}{}{You don't have time for this!}
 {258}{}{Go, while you still can!}
 {259}{}{Don't you understand? Without it you'll be dead in a matter of hours.}
-{260}{}{Oh, well, if that's the case. Stick away, doc. What happens when the F.E.V. toxin is released?}
+{260}{}{Oh, well, if that's the case. Stick away, doc. What happens when the FEV toxin is released?}
 {261}{}{No needles, no way, no how. I'll take my chances.}
 {262}{}{You'll never make it to free your people unless you're inoculated. What's the matter? Afraid of a little prick?}
-{263}{}{No, I guess not. As long as I don't watch you do it. Youch! So, what happens when you release the F.E.V. toxin?}
+{263}{}{No, I guess not. As long as I don't watch you do it. Youch! So, what happens when you release the FEV toxin?}

--- a/data/text/english/dialog/qcfrank.msg
+++ b/data/text/english/dialog/qcfrank.msg
@@ -19,7 +19,7 @@
 {114}{}{Can't we talk this over?}
 
 # Node 4
-{115}{ssa4a}{Dumping the F.E.V. toxin into our air doesn't make you a hero. You're just another mutant that needs to be put down.}
+{115}{ssa4a}{Dumping the FEV toxin into our air doesn't make you a hero. You're just another mutant that needs to be put down.}
 {116}{ssa4b}{Making our reactor melt-down means that things are going to be pretty hot in here soon. Pity you won't live long enough to see it. You're not a hero; you're just a walking corpse.}
 {117}{}{You talk the talk but can you walk the walk? I don't think so.}
 {118}{}{Wait a minute! Hold on! Can't we talk this over?}

--- a/data/text/english/dialog/qcmartin.msg
+++ b/data/text/english/dialog/qcmartin.msg
@@ -38,7 +38,7 @@
 {137}{}{What kind of virus?}
 {138}{}{That doesn't sound good. Let me ask you something else.}
 {139}{}{Lucky you. Maybe now you know the pain my ancestor, the Vault Dweller, felt. I hope you all burn. Goodbye.}
-{140}{}{They call it the F.E.V. toxin. It does horrible things to people, before it kills them. The only *good* thing about it is that it kills so quickly. Sure looks painful though.}
+{140}{}{They call it the FEV toxin. It does horrible things to people, before it kills them. The only *good* thing about it is that it kills so quickly. Sure looks painful though.}
 {141}{}{That sounds nasty. Why are they using your people for a test?}
 {142}{}{They took us all from our vault because they wanted test subjects for the antidote. They needed people from outside the Enclave, and who were still pure-strain-humans. So they took us.}
 {143}{}{They took you? How, from where?}

--- a/data/text/english/dialog/qhprzrch.msg
+++ b/data/text/english/dialog/qhprzrch.msg
@@ -10,7 +10,7 @@
 {108}{}{Bye-bye.}
 
 {109}{prs2a}{Ah, affected by the test serums, I see. Um, I'll get you some help. Guards!}
-{110}{prs2b}{Doctor, I think you've been exposed to the F.E.V. Poor soul, I'll get you some help. Guards!}
+{110}{prs2b}{Doctor, I think you've been exposed to the FEV Poor soul, I'll get you some help. Guards!}
 {111}{prs2c}{Now be a good mutant and stay put. Guards!}
 {112}{}{OK.}
 {113}{}{Uh uh. Bye bye.}
@@ -125,7 +125,7 @@
 {199}{prs26}{Vice-President Bird may look like a drooling idiot, but I'll have you know that man's a national hero.}
 {200}{}{To you, probably.}
 
-{201}{prs27}{He's one of the bravest men I know. He volunteered to try one of the early versions of the F.E.V. toxin antidote. (sigh) Unfortunately, it didn't quite work out the way we'd hoped.}
+{201}{prs27}{He's one of the bravest men I know. He volunteered to try one of the early versions of the FEV toxin antidote. (sigh) Unfortunately, it didn't quite work out the way we'd hoped.}
 {202}{}{You mean that wasn't what you'd hoped for?}
 
 {203}{prs28}{It's tiny mocking minds like yours that prove the superiority of real humans over mutants.}
@@ -183,7 +183,7 @@
 {240}{prs41}{We found a research facility in operational shape about 70 years ago. A former military base that had been used to research a special virus.}
 {241}{}{A virus?}
 
-{242}{prs42}{Yes, the F.E.V. virus. It was originally developed to turn soldiers into super-warriors but it failed. The warriors were tough and strong, but far too stupid. However, our brilliant Chemical Corps altered it.}
+{242}{prs42}{Yes, the FEV virus. It was originally developed to turn soldiers into super-warriors but it failed. The warriors were tough and strong, but far too stupid. However, our brilliant Chemical Corps altered it.}
 {243}{}{Altered the virus? Why?}
 
 {244}{prs43}{To turn it into a staggeringly effective killer. Any humanoid that isn't inoculated against its effects before its release will die. That is the Project.}
@@ -204,10 +204,10 @@
 {254}{prs46b}{Some of the members of your tribe are showing some extremely interesting changes. If the danger to true humanity weren't so great I would think about studying them. But (sighs) that's not to be.}
 {255}{}{Not to be? Why not?}
 
-{256}{prs47}{Oh, but that's one of the advantages of the F.E.V. virus. We can release it right here and the Jet stream will carry it worldwide. It'll have plenty of time to cleanse every nook and cranny of the globe.}
+{256}{prs47}{Oh, but that's one of the advantages of the FEV virus. We can release it right here and the Jet stream will carry it worldwide. It'll have plenty of time to cleanse every nook and cranny of the globe.}
 {257}{}{OK. Then why did you have to kidnap my villagers and the people from Vault 13?}
 
-{258}{prs48}{Test subjects. Your villagers are all descended from vault stock and we had to make sure that the F.E.V. toxin was still effective. The subjects from Vault 13 test that and an inoculation against the FEV.}
+{258}{prs48}{Test subjects. Your villagers are all descended from vault stock and we had to make sure that the FEV toxin was still effective. The subjects from Vault 13 test that and an inoculation against the FEV.}
 {259}{}{You're not testing the inoculation on my people?}
 
 {260}{prs48a}{It's hardly necessary. I'm sure we could and it would work, but there's no reason to do so.}
@@ -248,8 +248,8 @@
 {285}{}{Uh, yes, sir. Whatever you say, sir.}
 {286}{}{Oh, I'll be able to find my own way back, sir. Goodbye.}
 
-{287}{prs60}{Why, against the F.E.V. toxin, of course. Damn brave sacrifice you and the other members of Vault 13 are making. On behalf of the United States government, and all humanity, I thank you. Now, we better get you back to your ward.}
-{288}{}{F.E.V. toxin? What the hell are you talking about? What's going on here?}
+{287}{prs60}{Why, against the FEV toxin, of course. Damn brave sacrifice you and the other members of Vault 13 are making. On behalf of the United States government, and all humanity, I thank you. Now, we better get you back to your ward.}
+{288}{}{FEV toxin? What the hell are you talking about? What's going on here?}
 {289}{}{Uh, yes sir. Whatever you say, sir.}
 {290}{}{Oh, I'll be able to find my own way back, sir. Goodbye.}
 

--- a/data/text/english/dialog/vccharly.msg
+++ b/data/text/english/dialog/vccharly.msg
@@ -10,8 +10,8 @@
 {109}{}{You see Charlie... he looks like he has put on weight, and is breathing normally.}
 {110}{}{This man has radiation poisoning. Your skills can't help him. He needs medication.}
 {111}{}{This man looks terribly sick. You're not sure what's wrong.}
-{112}{}{Thanks, but I'm fine, really. That Rad-Away stuff did the trick.}
-{113}{}{You find a vein and inject the Rad-Away into Charlie's system.}
+{112}{}{Thanks, but I'm fine, really. That RadAway stuff did the trick.}
+{113}{}{You find a vein and inject the RadAway into Charlie's system.}
 {114}{}{*Urhkkkk*...}
 {115}{}{3 Seconds}
 {116}{}{Unhhhhh...*cough* *cough*...}
@@ -26,9 +26,9 @@
 {125}{}{*Urhkkkk*}
 {126}{}{Last time I drink the damned water in this town, that's fer sure.}
 {127}{}{Surprised I still ain't glowing...}
-{128}{}{Damn Rad-Away gives me the runs...}
+{128}{}{Damn RadAway gives me the runs...}
 {129}{}{Thanks, stranger. I appreciate your help... I couldn't afford the Auto-Doc.}
 {130}{}{Wish I could reward you, but I ain't even got two caps to rub together.}
 {131}{}{Last time I drink the damned water in this town, that's fer sure.}
 {132}{}{Surprised I still ain't glowing...}
-{133}{}{Damn Rad-Away gives me the runs...}
+{133}{}{Damn RadAway gives me the runs...}

--- a/data/text/english/dialog/vcdrtroy.msg
+++ b/data/text/english/dialog/vcdrtroy.msg
@@ -163,7 +163,7 @@
  manufacturing drugs. His manners and language also leave MUCH to be desired.}
 {233}{}{Tell me about it.}
 {234}{}{Maybe you should loosen up a little, Doc. A little drug use never hurt anyone. Well, except for
- those super stimpacks... and Buffout... and Psycho. Actually, never mind. I'll be going.}
+ those super stimpaks... and Buffout... and Psycho. Actually, never mind. I'll be going.}
 {235}{}{I'll pass that along.}
 {236}{}{Yes, I'm willing to pay you a thousand dollars for the sample... and your silence.}
 {237}{}{I have a sample of Jet right here.}
@@ -309,7 +309,7 @@
 {352}{}{Well, thanks anyway.}
 {353}{}{Well, thanks anyway. Maybe I can find somebody else to perform the operation.}
 {354}{}{I'm sorry. The facilities are only for Citizens, and a list of all patients is kept in the
- database... [Lowers voice.] However, the stimpacks in the lower level supply lockers would not be missed
+ database... [Lowers voice.] However, the stimpaks in the lower level supply lockers would not be missed
  if you put them to good use.}
 {355}{}{Hmmm. Okay, I had some other questions...}
 {356}{}{Thanks. I'll go look for them.}

--- a/data/text/english/dialog/vcfarrel.msg
+++ b/data/text/english/dialog/vcfarrel.msg
@@ -12,7 +12,7 @@
 {109}{}{Vault City prevails, Citizen.}
 {110}{}{A mutant! Guards! Guards!}
 {111}{}{A ghoul! Guards! Guards!}
-{112}{}{Let's see... three stimpacks, one box of Rad-X...}
+{112}{}{Let's see... three stimpaks, one box of Rad-X...}
 {113}{}{Still need to make that inventory list for Officer Randal.}
 {114}{}{Let's see: need to check the stock, list the inventory, check the list, then enter the list
  into the system...}

--- a/data/text/english/dialog/vcnancy.msg
+++ b/data/text/english/dialog/vcnancy.msg
@@ -10,7 +10,7 @@
 {109}{}{Let's see. We have three Servant inoculations scheduled for 1400...}
 {110}{}{All that beeping is driving me crazy...}
 {111}{}{I swear those medical databases are talking amongst themselves...}
-{112}{}{Let's see... three hypodermics, antiseptic, three ampoules of RadX...}
+{112}{}{Let's see... three hypodermics, antiseptic, three ampoules of Rad-X...}
 {113}{}{Better prep Dr. Troy on that seminar for tomorrow...}
 {114}{}{Yeah, they have me working late AGAIN. Mostly making lists.}
 {115}{}{You might want to come back in the morning.}

--- a/data/text/english/dialog/vcrandal.msg
+++ b/data/text/english/dialog/vcrandal.msg
@@ -58,7 +58,7 @@
 {157}{}{Councilor McClure said you'd have a hydroelectric magnetosphere regulator in stock that I could have.}
 {158}{}{The First Citizen sent me here to claim my reward.}
 {159}{}{Nothing today, actually.}
-{160}{}{This is the Amenities Office. Got your typical stock... basic living necessities, some books, "how to" manuals, some tools, stimpacks, medical supplies, this and that.}
+{160}{}{This is the Amenities Office. Got your typical stock... basic living necessities, some books, "how to" manuals, some tools, stimpaks, medical supplies, this and that.}
 {161}{}{Sounds great. Can I see what you have in stock?}
 {162}{}{Do you have a GECK?}
 {163}{}{Valerie over at the maintenance shed could use a new wrench and some pliers.}

--- a/data/text/english/game/cmbatai2.msg
+++ b/data/text/english/game/cmbatai2.msg
@@ -625,14 +625,14 @@
 #
 {1760}{}{Dammit! My leg!}
 {1761}{}{I don't need two legs to kick your ass.}
-{1762}{}{Gonna need a stimpack for my leg...}
+{1762}{}{Gonna need a stimpak for my leg...}
 {1763}{}{Urggg... leg's... screwed...}
 #
 # target hit in left leg
 #
 {1770}{}{Dammit! My leg!}
 {1771}{}{*Ergg* Gonna have a limp after that one...}
-{1772}{}{Gonna need a stimpack for my leg...}
+{1772}{}{Gonna need a stimpak for my leg...}
 {1773}{}{Urggg... leg's... screwed...}
 #
 # target hit in eyes
@@ -662,21 +662,21 @@
 {1801}{}{What just hit me in the head?}
 {1802}{}{Ngggg}
 {1803}{}{Glad I'm dusted on Jet, or that would have hurt.}
-{1804}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1804}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in left arm
 #
 {1810}{}{Hey! Somebody just hit my arm!}
 {1811}{}{Look, my arm is for needles only. Stop attacking it.}
 {1812}{}{Nggggg}
-{1813}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1813}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in right arm
 #
 {1820}{}{Hey! Somebody just hit my arm!}
 {1821}{}{Look, my arm is for needles only. Stop attacking it.}
 {1822}{}{Nggggg}
-{1823}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1823}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in torso
 #
@@ -687,19 +687,19 @@
 {1834}{}{Whoa. My chest. You hit it. Cool.}
 {1835}{}{Nrgggg}
 {1836}{}{*hfff*}
-{1837}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1837}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in right leg
 #
 {1860}{}{Hey! Somebody just hit my leg!}
 {1861}{}{Hey! I walk with that leg!}
-{1862}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1862}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in left leg
 #
 {1870}{}{Hey! Somebody just hit my leg!}
 {1871}{}{Hey! I walk with that leg!}
-{1872}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1872}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in eyes
 #
@@ -1365,7 +1365,7 @@
 # moving in to attack
 #
 {3220}{}{Eat this!}
-{3221}{}{You better hope you have some stimpacks... or some Jet.}
+{3221}{}{You better hope you have some stimpaks... or some Jet.}
 {3222}{}{Maybe I can sell your body for some Jet...}
 {3223}{}{Gonna... hit... you... when... I...catch... you.}
 {3224}{}{Maybe killing you will be the fix I need...}
@@ -1469,7 +1469,7 @@
 {12027}{}{Lock and load!}
 {12028}{}{Rock and roll!}
 {12029}{}{Look who just walked into the free fire zone...}
-{12030}{}{Better hope you packed some stimpacks, tribal...}
+{12030}{}{Better hope you packed some stimpaks, tribal...}
 {12031}{}{Contact!}
 {12032}{}{The area's been breached!}
 {12033}{}{We got us an intruder, boys!}
@@ -1489,7 +1489,7 @@
 {12045}{}{You want some of this?! YOU WANT SOME OF THIS?!}
 {12046}{}{Hiyaaaaaa!!!}
 {12047}{}{Get some!}
-{12048}{}{Better hope you packed some stimpacks, tribal...}
+{12048}{}{Better hope you packed some stimpaks, tribal...}
 {12049}{}{Kiss your ass good-bye...}
 #
 # target being missed
@@ -1554,9 +1554,9 @@
 {12200}{}{Whoa, this shit's getting too heavy.}
 {12201}{}{Time to go get some of the other boys...}
 {12202}{}{I'll get you next time!}
-{12203}{}{You're just lucky I ain't got no stimpacks on me...}
+{12203}{}{You're just lucky I ain't got no stimpaks on me...}
 {12204}{}{Time to get the hell outta Dodge.}
-{12205}{}{Need to find some stimpacks, fast...}
+{12205}{}{Need to find some stimpaks, fast...}
 #
 # moving in to attack
 #
@@ -1629,14 +1629,14 @@
 #
 {12360}{}{Dammit! My leg!}
 {12361}{}{*Ergg*}
-{12362}{}{Gonna need a stimpack for my leg...}
+{12362}{}{Gonna need a stimpak for my leg...}
 {12363}{}{Urggg... leg's... screwed...}
 #
 # target hit in left leg
 #
 {12370}{}{Dammit! My leg!}
 {12371}{}{*Ergg*}
-{12372}{}{Gonna need a stimpack for my leg...}
+{12372}{}{Gonna need a stimpak for my leg...}
 {12373}{}{Urggg... leg's... screwed...}
 #
 # target hit in eyes

--- a/data/text/english/game/combatai.msg
+++ b/data/text/english/game/combatai.msg
@@ -898,14 +898,14 @@
 #
 {1760}{}{Dammit! My leg!}
 {1761}{}{I don't need two legs to kick your ass.}
-{1762}{}{Gonna need a stimpack for my leg...}
+{1762}{}{Gonna need a stimpak for my leg...}
 {1763}{}{Urggg... leg's... screwed...}
 #
 # target hit in left leg
 #
 {1770}{}{Dammit! My leg!}
 {1771}{}{*Ergg* Gonna have a limp after that one...}
-{1772}{}{Gonna need a stimpack for my leg...}
+{1772}{}{Gonna need a stimpak for my leg...}
 {1773}{}{Urggg... leg's... screwed...}
 #
 # target hit in eyes
@@ -935,21 +935,21 @@
 {1801}{}{What just hit me in the head?}
 {1802}{}{Ngggg}
 {1803}{}{Glad I'm dusted on Jet, or that would have hurt.}
-{1804}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1804}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in left arm
 #
 {1810}{}{Hey! Somebody just hit my arm!}
 {1811}{}{Look, my arm is for needles only. Stop attacking it.}
 {1812}{}{Nggggg}
-{1813}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1813}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in right arm
 #
 {1820}{}{Hey! Somebody just hit my arm!}
 {1821}{}{Look, my arm is for needles only. Stop attacking it.}
 {1822}{}{Nggggg}
-{1823}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1823}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in torso
 #
@@ -960,19 +960,19 @@
 {1834}{}{Whoa. My chest. You hit it. Cool.}
 {1835}{}{Nrgggg}
 {1836}{}{*hfff*}
-{1837}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1837}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in right leg
 #
 {1860}{}{Hey! Somebody just hit my leg!}
 {1861}{}{Hey! I walk with that leg!}
-{1862}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1862}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in left leg
 #
 {1870}{}{Hey! Somebody just hit my leg!}
 {1871}{}{Hey! I walk with that leg!}
-{1872}{}{Owwwww! Somebody get me a stimpack! Or some Jet!}
+{1872}{}{Owwwww! Somebody get me a stimpak! Or some Jet!}
 #
 # target hit in eyes
 #
@@ -1319,7 +1319,7 @@
 {2313}{}{That was fun, ta ta.}
 {2314}{}{Whoa, time for my lunch-break.}
 {2315}{}{That was great, I broke a sweat!}
-{2316}{}{Time for more ammo and stimpacks!}
+{2316}{}{Time for more ammo and stimpaks!}
 {2317}{}{Hold it right there, I'll be back in a few.}
 {2318}{}{I've got some friends that'll want in on this action.}
 {2319}{}{Let's do that again, real soon.}
@@ -1826,7 +1826,7 @@
 # moving in to attack
 #
 {3220}{}{Eat this!}
-{3221}{}{You better hope you have some stimpacks... or some Jet.}
+{3221}{}{You better hope you have some stimpaks... or some Jet.}
 {3222}{}{Maybe I can sell your body for some Jet...}
 {3223}{}{Gonna... hit... you... when... I...catch... you.}
 {3224}{}{Maybe killing you will be the fix I need...}
@@ -1979,8 +1979,8 @@
 {10147}{}{Danger Bill Williamson, Danger!}
 {10148}{}{Gort! Klaatu Berada Nictu!}
 {10149}{}{Sssszzzzztt *POP*}
-{10150}{}{Would you like cream with that Ma'am?}
-{10151}{}{Yes Sir, a Mr, Handy unit, Sir.}
+{10150}{}{Would you like cream with that, ma'am?}
+{10151}{}{Yes sir, a Mr. Handy unit, sir.}
 {10152}{}{I'm fully proficient.}
 {10153}{}{But I'm a translator.}
 {10154}{}{Nanoo-nanoo.}
@@ -2028,7 +2028,7 @@
 {12027}{}{Lock and load!}
 {12028}{}{Rock and roll!}
 {12029}{}{Look who just walked into the free fire zone...}
-{12030}{}{Better hope you packed some stimpacks, tribal...}
+{12030}{}{Better hope you packed some stimpaks, tribal...}
 {12031}{}{Contact!}
 {12032}{}{The area's been breached!}
 {12033}{}{We got us an intruder, boys!}
@@ -2048,7 +2048,7 @@
 {12045}{}{You want some of this?! YOU WANT SOME OF THIS?!}
 {12046}{}{Hiyaaaaaa!!!}
 {12047}{}{Get some!}
-{12048}{}{Better hope you packed some stimpacks, tribal...}
+{12048}{}{Better hope you packed some stimpaks, tribal...}
 {12049}{}{Kiss your ass good-bye...}
 #
 # target being missed
@@ -2113,9 +2113,9 @@
 {12200}{}{Whoa, this shit's getting too heavy.}
 {12201}{}{Time to go get some of the other boys...}
 {12202}{}{I'll get you next time!}
-{12203}{}{You're just lucky I ain't got no stimpacks on me...}
+{12203}{}{You're just lucky I ain't got no stimpaks on me...}
 {12204}{}{Time to get the hell outta Dodge.}
-{12205}{}{Need to find some stimpacks, fast...}
+{12205}{}{Need to find some stimpaks, fast...}
 #
 # moving in to attack
 #
@@ -2188,14 +2188,14 @@
 #
 {12360}{}{Dammit! My leg!}
 {12361}{}{*Ergg*}
-{12362}{}{Gonna need a stimpack for my leg...}
+{12362}{}{Gonna need a stimpak for my leg...}
 {12363}{}{Urggg... leg's... screwed...}
 #
 # target hit in left leg
 #
 {12370}{}{Dammit! My leg!}
 {12371}{}{*Ergg*}
-{12372}{}{Gonna need a stimpack for my leg...}
+{12372}{}{Gonna need a stimpak for my leg...}
 {12373}{}{Urggg... leg's... screwed...}
 #
 # target hit in eyes
@@ -4624,7 +4624,7 @@
 # target hit in head
 #
 {42000}{}{ignore the pain in my head ignore the pain in my head}
-{42001}{}{Aighh! There's blood all over my face! Help! Stimpack! Help!}
+{42001}{}{Aighh! There's blood all over my face! Help! Stimpak! Help!}
 {42002}{}{MY HEAD! MY HEAD! I'VE BEEN HIT IN THE HEAD! HELP! HELP!}
 {42003}{}{Oooooooh. There goes a few Intelligence points.}
 {42004}{}{Are these pieces of my brain in my hands?}
@@ -4637,7 +4637,7 @@
 # target hit in left arm
 #
 {42010}{}{ignore the pain in my arm ignore the pain in my arm}
-{42011}{}{Aighh! There's blood all over my arm! Help! Stimpack! Help!}
+{42011}{}{Aighh! There's blood all over my arm! Help! Stimpak! Help!}
 {42012}{}{MY ARM! MY ARM! I'VE BEEN HIT IN THE ARM! HELP! HELP!}
 {42013}{}{Not my left arm! That's my strong arm!}
 {42014}{}{Not my hand! Rosie! Rosie Palmer! Speak to me, girl!}
@@ -4648,7 +4648,7 @@
 # target hit in right arm
 #
 {42020}{}{ignore the pain in my arm ignore the pain in my arm}
-{42021}{}{Aighh! There's blood all over my arm! Help! Stimpack! Help!}
+{42021}{}{Aighh! There's blood all over my arm! Help! Stimpak! Help!}
 {42022}{}{MY ARM! MY ARM! I'VE BEEN HIT IN THE ARM! HELP! HELP!}
 {42023}{}{Not my hand! Rosie! Rosie Palmer! Speak to me, girl!}
 {42024}{}{Aighhh! My funny bone! I... I...I... must keep... from... laughing...}
@@ -4661,7 +4661,7 @@
 {42030}{}{ignore the pain in my chest ignore the pain in my chest}
 {42031}{}{My pocket protector!}
 {42032}{}{*Unfff*...hey... that... was my... last clean shirt.}
-{42033}{}{Aighh! There's blood all over my chest! Help! Stimpack! Help!}
+{42033}{}{Aighh! There's blood all over my chest! Help! Stimpak! Help!}
 {42034}{}{MY CHEST! MY CHEST! I'VE BEEN HIT IN THE CHEST! HELP! HELP!}
 {42035}{}{*Urkkk*...chest... feels like it's on fire...}
 {42036}{}{What the hell is all this blood... doing... on... my... chest...*urkkk*}
@@ -4692,7 +4692,7 @@
 # target hit in right leg
 #
 {42060}{}{ignore the pain in my leg ignore the pain in my leg}
-{42061}{}{Aighh! There's blood all over my leg! Help! Stimpack! Help!}
+{42061}{}{Aighh! There's blood all over my leg! Help! Stimpak! Help!}
 {42062}{}{MY LEG! MY LEG! I'VE BEEN HIT IN THE LEG! HELP! HELP!}
 {42063}{}{Aieeeee! I can't feel my right leg!}
 {42064}{}{Owwww! My shin!}
@@ -4704,7 +4704,7 @@
 # target hit in left leg
 #
 {42070}{}{ignore the pain in my leg ignore the pain in my leg}
-{42071}{}{Aighh! There's blood all over my leg! Help! Stimpack! Help!}
+{42071}{}{Aighh! There's blood all over my leg! Help! Stimpak! Help!}
 {42072}{}{MY LEG! MY LEG! I'VE BEEN HIT IN THE LEG! HELP! HELP!}
 {42073}{}{Aieeee! I can't feel my left leg!}
 {42074}{}{Owwww! My shin!}
@@ -4717,7 +4717,7 @@
 #
 {42080}{}{Yuh-yuh-you... huh-huh-hit me in the uh-uh-eye...}
 {42081}{}{My eye! My eye! Help! Somebody help!}
-{42082}{}{Aighh! I can't see! Help! Stimpack! Help!}
+{42082}{}{Aighh! I can't see! Help! Stimpak! Help!}
 {42083}{}{MY EYE! MY EYE!}
 {42084}{}{I'm blind! And not from masturbating!}
 {42085}{}{Owwwww! My eye! My eye!}
@@ -4734,7 +4734,7 @@
 {42093}{}{I've been Bobbit-ized!}
 {42094}{}{please let my balls be okay please let my balls be okay}
 {42095}{}{Help! I got hit in the groin! Help!}
-{42096}{}{I'm going to need fifteen stimpacks once the pain from my groin reaches my brain.}
+{42096}{}{I'm going to need fifteen stimpaks once the pain from my groin reaches my brain.}
 {42097}{}{My groin! Little Myron... speak to me, pal! Speak to me!}
 {42098}{}{Looks like it's prosthetic city when I go to the whorehouse again...}
 {42099}{}{Hitting people in the balls is MY shtick. Thanks a lot.}

--- a/data/text/english/game/custom.msg
+++ b/data/text/english/game/custom.msg
@@ -63,7 +63,7 @@
 # Drug use options.
 #
 {600}{}{I'm clean}
-{601}{}{Stimpacks when hurt a bit}
-{602}{}{Stimpacks when hurt a lot}
+{601}{}{Stimpaks when hurt a bit}
+{602}{}{Stimpaks when hurt a lot}
 {603}{}{Any drug some of the time}
 {604}{}{Any drug any time}

--- a/data/text/english/game/editor.msg
+++ b/data/text/english/game/editor.msg
@@ -245,7 +245,7 @@
 {1001}{}{Berserker}
 {1002}{}{Champion}
 {1003}{}{Childkiller}
-{1004}{}{Nuka Cola addiction}
+{1004}{}{Nuka-Cola addiction}
 {1005}{}{Buffout addiction}
 {1006}{}{Mentats addiction}
 {1007}{}{Psycho addiction}

--- a/data/text/english/game/pipboy.msg
+++ b/data/text/english/game/pipboy.msg
@@ -897,7 +897,7 @@
 {14066}{}{**END-PAR**}
 {14067}{}{BROKEN HILLS: A mining community to the south of Vault}
 {14068}{}{City that mines uranium ore. The ore is traded to Vault}
-{14069}{}{City in exchange for medical supplies, mostly RadX and}
+{14069}{}{City in exchange for medical supplies, mostly Rad-X and}
 {14070}{}{RadAway. Humans are believed to be forced to live with}
 {14071}{}{mutants and ghouls within the town. Due to the nature}
 {14072}{}{of the inhabitants and the high probability of}
@@ -1113,21 +1113,21 @@
 {20004}{}{**END-PAR**}
 {20005}{}{It is my honor, and happy privilege, to report the near}
 {20006}{}{completion of The Project. After years of work, we've }
-{20007}{}{managed to isolate the most toxic elements of the F.E.V.}
+{20007}{}{managed to isolate the most toxic elements of the FEV}
 {20008}{}{virus. Some of the only recently decoded information}
 {20009}{}{that we retrieved from the abandoned military base on the}
 {20010}{}{mainland has been instrumental in advancing our research.}
 {20011}{}{**END-PAR**}
-{20012}{}{We've discovered that the F.E.V. virus was not originally}
+{20012}{}{We've discovered that the FEV virus was not originally}
 {20013}{}{designed to be used as an agent for the creation of}
-{20014}{}{super-soldiers. Initially, it appears, the F.E.V. was }
-{20015}{}{designed as a virulent toxin. Only later was the F.E.V.}
+{20014}{}{super-soldiers. Initially, it appears, the FEV was }
+{20015}{}{designed as a virulent toxin. Only later was the FEV}
 {20016}{}{virus manipulated in an attempt to create super-soldiers.}
 {20017}{}{**END-PAR**}
 {20018}{}{By backtracking somewhat in our research, and with the}
 {20019}{}{help of the additional information from the military }
 {20020}{}{base's records, we've been able to turn our version of }
-{20021}{}{the F.E.V. (F.E.V. Curling-13) into a far more toxic }
+{20021}{}{the FEV (FEV Curling-13) into a far more toxic }
 {20022}{}{agent.}
 {20023}{}{**END-PAR**}
 {20024}{}{Final tests conducted on the vault-descendant subjects,}
@@ -1139,18 +1139,18 @@
 {20030}{}{one-hour of exposure, with death not occurring, on }
 {20031}{}{average, for another 14.5 hours.}
 {20032}{}{**END-PAR**}
-{20033}{}{In either case, the F.E.V.'s toxicity levels are now }
+{20033}{}{In either case, the FEV's toxicity levels are now }
 {20034}{}{sufficient to insure a "clean-sweep" of all infested }
 {20035}{}{(i.e. non-Enclave) locales. Current releasable levels }
-{20036}{}{of F.E.V. Curling-13 show a 95% probability of .00007%}
+{20036}{}{of FEV Curling-13 show a 95% probability of .00007%}
 {20037}{}{average saturation. While the consensus of the Chemical}
 {20038}{}{Corps is that this would be a sufficient level to insure}
 {20039}{}{the success of the Project, we believe that it is worth}
-{20040}{}{waiting until we can accumulate enough F.E.V. toxin to}
+{20040}{}{waiting until we can accumulate enough FEV toxin to}
 {20041}{}{reach our .0001% saturation and 99.5% extermination }
 {20042}{}{level goal.}
 {20043}{}{**END-PAR**}
-{20044}{}{Current F.E.V. Curling-13 production levels show that}
+{20044}{}{Current FEV Curling-13 production levels show that}
 {20045}{}{we'll reach our release goal, of 250,000 gallons, within}
 {20046}{}{six weeks.}
 {20047}{}{**END-PAR**}

--- a/data/text/english/game/pro_item.msg
+++ b/data/text/english/game/pro_item.msg
@@ -646,8 +646,8 @@
 {32801}{}{This black sphere is some strange precognitive device... a small window on the top seems to be able to predict the future! Pre-war humanity must have been geniuses to invent such a wonder!}
 {32900}{}{Mutagenic Serum}
 {32901}{}{A strange organic concoction that could possibly reverse the Mutation Factor in humans.}
-{33000}{}{Crashed Verti-Bird}
-{33001}{}{This is wreckage from a verti-bird. Looks like it crashed here months ago.}
+{33000}{}{Crashed Vertibird}
+{33001}{}{This is wreckage from a vertibird. Looks like it crashed here months ago.}
 {33100}{}{Cat's Paw Issue #5}
 {33101}{}{This is the hard to find Issue 5 of Cat's Paw magazine. The pictures aside, this issue has a wonderful article on energy weapons.}
 {33200}{}{M3A1 "Grease Gun" SMG}


### PR DESCRIPTION
There are some terms that have different spelling accross the files. I've changed the ones with minor occurences for more consistency, also in regard to their usage in Fallout 1. 

Changes:
Nuka Cola -> Nuka-Cola
Stimpack -> Stimpak
F.E.V. -> FEV
Rad-Away -> RadAway
RadX -> Rad-X
Verti-Bird -> Vertibird