### PR TITLE
Rearrange components for the installer

### DIFF
--- a/extra/inno/components_ammo.iss
+++ b/extra/inno/components_ammo.iss
@@ -1,4 +1,4 @@
-Name: "ammo"; Description: "Ammo damage formula"; Types: "custom";
+Name: "ammo"; Description: "Ammo damage formula"; Types: "custom"; Flags: fixed;
 Name: "ammo\default"; Description: "Default"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\glovz"; Description: "Glovz's"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\yaam"; Description: "YAAM"; Flags: exclusive disablenouninstallwarning;

--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -51,6 +51,8 @@ Name: "core"; Description: "Core"; Types: "custom"; Flags: fixed;
 Name: "translation"; Description: "Language"; Types: "custom"; Flags: fixed;
 #include "components_translations.iss"
 
+#include "components_ammo.iss"
+
 Name: "walk_speed"; Description: "Walk speed fix"; Types: "custom";
 Name: "walk_speed\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
@@ -58,8 +60,6 @@ Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenoun
 Name: "goris"; Description: "Faster derobing for Goris"; Types: "custom";
 Name: "goris\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "goris\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
-
-#include "components_ammo.iss"
 
 Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
 

--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -48,10 +48,6 @@ Filename: "{app}\{#basename}-install.bat"; Parameters: "> {#backup_dir}\log.txt 
 
 [Components]
 Name: "core"; Description: "Core"; Types: "custom"; Flags: fixed;
-Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
-
-#include "components_ammo.iss"
-
 Name: "translation"; Description: "Language"; Types: "custom"; Flags: fixed;
 #include "components_translations.iss"
 
@@ -62,6 +58,10 @@ Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenoun
 Name: "goris"; Description: "Faster derobing for Goris"; Types: "custom";
 Name: "goris\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "goris\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
+
+#include "components_ammo.iss"
+
+Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
 
 [Types]
 Name: "custom"; Description: "Custom Selection"; Flags: iscustom


### PR DESCRIPTION
Left - previous, Right - this PR.
![upu_instx](https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/assets/8564973/84355060-0033-4494-8ca2-f170d50c92d3)

Same as RPU, moving language options to right after the core component.