### PR TITLE
Add some missing "pre-placed" items to VC trader restock lists

### DIFF
--- a/scripts_src/ncr/sishelf2.ssl
+++ b/scripts_src/ncr/sishelf2.ssl
@@ -196,7 +196,7 @@ procedure map_enter_p_proc begin
    if (buster_obj != -1 and buster_obj) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box = move_quest_items();
+         variable tmp_box := move_quest_items();
          //Common
          check_restock_item(PID_KNIFE, 1, 5, 100)
          check_restock_item(PID_CLUB, 1, 5, 100)
@@ -219,7 +219,6 @@ procedure map_enter_p_proc begin
          //Really rare
          check_restock_item(PID_POWER_FIST, 1, 1, 5)
 
-         check_restock_item(PID_RIPPER, 0, 2, 100)
          check_restock_item(PID_223_PISTOL, 1, 3, 100)
          check_restock_item(PID_10MM_JHP, 5, 10, 100)
          check_restock_item(PID_SHOTGUN_SHELLS, 5, 10, 100)

--- a/scripts_src/ncr/sishelf2.ssl
+++ b/scripts_src/ncr/sishelf2.ssl
@@ -196,7 +196,7 @@ procedure map_enter_p_proc begin
    if (buster_obj != -1 and buster_obj) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box := move_quest_items();
+         variable tmp_box = move_quest_items();
          //Common
          check_restock_item(PID_KNIFE, 1, 5, 100)
          check_restock_item(PID_CLUB, 1, 5, 100)

--- a/scripts_src/valtcity/viharbox.ssl
+++ b/scripts_src/valtcity/viharbox.ssl
@@ -48,7 +48,7 @@ procedure map_enter_p_proc begin
    if (is_loading_game == false) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box := move_quest_items();
+         variable tmp_box = move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 150, 390, 100)
          check_restock_item(PID_KNIFE, 1, 3, 100)
          check_restock_item(PID_CROWBAR, 1, 2, 100)

--- a/scripts_src/valtcity/viharbox.ssl
+++ b/scripts_src/valtcity/viharbox.ssl
@@ -48,7 +48,7 @@ procedure map_enter_p_proc begin
    if (is_loading_game == false) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box = move_quest_items();
+         variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 150, 390, 100)
          check_restock_item(PID_KNIFE, 1, 3, 100)
          check_restock_item(PID_CROWBAR, 1, 2, 100)
@@ -59,6 +59,8 @@ procedure map_enter_p_proc begin
          check_restock_item(PID_SHOTGUN, 1, 2, 25)
          check_restock_item(PID_LEATHER_JACKET, 1, 2, 75)
          check_restock_item(PID_LEATHER_ARMOR, 1, 1, 50)
+         check_restock_item(PID_LEATHER_ARMOR_MK_II, 1, 1, 50)
+         check_restock_item(PID_MICRO_FUSION_CELL, 1, 1, 25)
          check_restock_item(PID_44_FMJ_MAGNUM, 2, 3, 100)
          check_restock_item(PID_44_MAGNUM_JHP, 2, 3, 100)
          check_restock_item(PID_10MM_AP, 2, 3, 100)
@@ -67,6 +69,7 @@ procedure map_enter_p_proc begin
          check_restock_item(PID_DYNAMITE, 1, 1, 50)
          check_restock_item(PID_SHOVEL, 1, 1, 50)
          check_restock_item(PID_FLARE, 1, 2, 50)
+         check_restock_item(PID_STIMPAK, 1, 2, 50)
          check_restock_item(PID_BEER, 1, 1, 100)
          check_restock_item(PID_BOOZE, 1, 1, 100)
          check_restock_item(PID_ROPE, 1, 1, 50)

--- a/scripts_src/valtcity/viranbox.ssl
+++ b/scripts_src/valtcity/viranbox.ssl
@@ -46,16 +46,20 @@ procedure map_enter_p_proc begin
    if (is_loading_game == false) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box = move_quest_items();
+         variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 200, 600, 100)
          check_restock_item(PID_BIG_BOOK_OF_SCIENCE, 1, 2, 75)
          check_restock_item(PID_DEANS_ELECTRONICS, 1, 1, 75)
          check_restock_item(PID_FIRST_AID_BOOK, 1, 1, 75)
          check_restock_item(PID_KNIFE, 1, 3, 100)
          check_restock_item(PID_10MM_PISTOL, 1, 2, 100)
+         check_restock_item(PID_DESERT_EAGLE, 1, 2, 100)
          check_restock_item(PID_SHOTGUN, 1, 2, 25)
          check_restock_item(PID_CLUB, 1, 1, 25)
+         check_restock_item(PID_LEATHER_ARMOR, 1, 2, 50)
+         check_restock_item(PID_LEATHER_ARMOR_MK_II, 1, 2, 50)
          check_restock_item(PID_METAL_ARMOR, 1, 2, 25)
+         check_restock_item(PID_METAL_ARMOR_MK_II, 1, 1, 25)
          check_restock_item(PID_10MM_JHP, 1, 3, 100)
          check_restock_item(PID_SHOTGUN_SHELLS, 1, 3, 100)
          check_restock_item(PID_STIMPAK, 3, 8, 100)

--- a/scripts_src/valtcity/viranbox.ssl
+++ b/scripts_src/valtcity/viranbox.ssl
@@ -46,7 +46,7 @@ procedure map_enter_p_proc begin
    if (is_loading_game == false) then begin
       restock_fix
       if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box := move_quest_items();
+         variable tmp_box = move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 200, 600, 100)
          check_restock_item(PID_BIG_BOOK_OF_SCIENCE, 1, 2, 75)
          check_restock_item(PID_DEANS_ELECTRONICS, 1, 1, 75)


### PR DESCRIPTION
Reference:
https://docs.google.com/spreadsheets/d/1tee2YHRWjgus2tolCTeqAH4iiAd5yfyg9utXyw5FU20/edit?usp=sharing

The merchant boxes on VC maps have pre-placed items instead of being empty by default like the rest, but some items were not in the restock list in scripts. I see this as a dev oversight between mapping/scripting since there's really no telling if they're meant to be unique, unlike the .223 pistol in Eldridge's special stock and the first aid kit in Renesco's stock that are specifically scripted.

I also remove a duplicate entry in `sishelf2.ssl`, because from the comment Ripper is supposed to be a rare item in Buster's stock.