### PR TITLE
fixed Metzger unable to start fight with dumb player

### DIFF
--- a/scripts_src/den/dcmetzge.ssl
+++ b/scripts_src/den/dcmetzge.ssl
@@ -802,7 +802,7 @@ procedure Node042 begin
 end
 procedure Node043 begin
    Reply(600);
-   BOption(601, Node998, 004);
+   BOption(601, Node998, 001);
    BOption(602, Node998, 004);
    prev_node := 30;
 end


### PR DESCRIPTION
Dumb player is allowed to become a slaver, but in case of abandon_slave_run Metzger can't start fight.

https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/blob/master/scripts_src/den/dcmetzge.ssl#L232

[SLOT06.zip](https://github.com/user-attachments/files/17593158/SLOT06.zip)

Here is fix.