### PR TITLE
Dumb player can't get reward from Vegeir

### DIFF
--- a/scripts_src/modoc/mcvegeir.ssl
+++ b/scripts_src/modoc/mcvegeir.ssl
@@ -238,13 +238,14 @@ procedure Node001 begin
    ndebug("get_ending_state/happy == " + get_ending_state+"/"+ending_state_happy);
    if ((get_ending_state == ending_state_happy) and (jonny_at_home == false)) then begin
       NOption(400,Node003,004);
+      NOption(g_grunt,Node003,-003);
    end
    NOption(157,Node026,004);
    NOption(158,Node028,004);
    if (jonny_request_home) then begin
       NOption(159,Node033,004);
    end
-   NOption(g_bye,Node999,004);
+   NOption(g_bye,Node999,001);
 end
 procedure Node002 begin
    Reply(160);


### PR DESCRIPTION
Dumb player can complete Jo/Vegeir quest, but can't get reward from Vegeir.
[SLOT10.zip](https://github.com/user-attachments/files/17651890/SLOT10.zip)

Option in Node003 means that dumb player should get reward:
https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/blob/master/scripts_src/modoc/mcvegeir.ssl#L274,
but he can't jump into Node003 because of missed option in Node001. I've added it and corrected Node999 option also.


